### PR TITLE
Anonymous contribution via gitGost

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ $ git clone git@github.com:maxim-smirnov/hik-qr-export.git
 $ cd hik-qr-export
 $ python3 -m venv venv  # Create new virtual environment
 $ source venv/bin/activate  # Activate venv
-$ pip install -r requirements.txt  # Install requirements 
+$ pip install -r requirements.txt  # Install requirements
 $ python hik_qr_export.py --help
 Usage: hik_qr_export.py [OPTIONS] COMMAND [ARGS]...
 
@@ -18,6 +18,11 @@ Options:
 Commands:
   decode  Decode QR code data, extract metadata and stored devices.
   renew   Renew QR code.
+```
+
+### Additional
+```bash
+$ pip install Pillow zxing-cpp  # Only if you want to use a QR image from clipboard
 ```
 
 # What and why?

--- a/hik_aes.py
+++ b/hik_aes.py
@@ -7,7 +7,15 @@ class HikAES(pyaes.AES):
         super().__init__(key)
 
     def decrypt_b64_to_str(self, ciphertext: str) -> str:
-        return ''.join(chr(c) for c in self.decrypt(base64.b64decode(ciphertext)))
+        raw = base64.b64decode(ciphertext)
+        plaintext = []
+        for i in range(0, len(raw), 16):
+            plaintext.extend(self.decrypt(list(raw[i:i + 16])))
+        return ''.join(chr(c) for c in plaintext)
 
     def encrypt_str_to_b64(self, plaintext: str) -> str:
-        return base64.b64encode(bytearray(self.encrypt(plaintext.encode()))).decode()
+        raw = plaintext.encode()
+        ciphertext = []
+        for i in range(0, len(raw), 16):
+            ciphertext.extend(self.encrypt(list(raw[i:i + 16])))
+        return base64.b64encode(bytearray(ciphertext)).decode()

--- a/hik_qr_export.py
+++ b/hik_qr_export.py
@@ -3,13 +3,50 @@ import datetime
 from qr_code_data import QrCodeData
 
 
+def _read_qr_from_clipboard() -> str:
+    """Read a QR code from the macOS clipboard image and return its text content.
+
+    Uses PIL.ImageGrab to capture the clipboard image and zxingcpp to decode
+    any QR codes found within.
+
+    Returns:
+        The text content of the single QR code found in the clipboard image.
+
+    Raises:
+        click.ClickException: If no image is in the clipboard, no QR code is
+            detected, or multiple QR codes are found.
+    """
+    import PIL.ImageGrab
+    import zxingcpp
+
+    image = PIL.ImageGrab.grabclipboard()
+    if image is None:
+        raise click.ClickException('No image found in clipboard.')
+
+    results = zxingcpp.read_barcodes(image)
+    qr_codes = [r for r in results if r.format == zxingcpp.BarcodeFormat.QRCode]
+
+    if not qr_codes:
+        raise click.ClickException('No QR code detected in the clipboard image.')
+    if len(qr_codes) > 1:
+        raise click.ClickException(f'Multiple QR codes detected ({len(qr_codes)}); expected exactly one.')
+
+    return qr_codes[0].text
+
+
 @click.group()
 def cli():
     pass
 
 @cli.command(help='Decode QR code data, extract metadata and stored devices.')
-@click.argument('qr_string')
-def decode(qr_string):
+@click.argument('qr_string', required=False, default=None)
+@click.option('-c', '--clipboard', is_flag=True, default=False, help='Read QR code image from macOS clipboard.')
+def decode(qr_string: str | None, clipboard: bool) -> None:
+    if clipboard:
+        qr_string = _read_qr_from_clipboard()
+    elif qr_string is None:
+        raise click.UsageError('Provide a QR string argument or use -c/--clipboard.')
+
     qr_code_data = QrCodeData.from_qr_string(qr_string)
     click.echo(f'Data header: {qr_code_data.header}')
     if qr_code_data.e2e_password:

--- a/local_device.py
+++ b/local_device.py
@@ -10,11 +10,15 @@ class LocalDevice:
     _username: str
     _password: str
 
+    _BLOCK_SIZE: int = 16
+    _MAX_BLOCKS: int = 2
+
     def __init__(self, name: str, ip_address: str, port: int, username: str, password: str):
-        if len(username) > 16:
-            raise InvalidLengthError('username length must be not more than 16 characters')
-        if len(password) > 16:
-            raise InvalidLengthError('password length must be not more than 16 characters')
+        max_len = self._BLOCK_SIZE * self._MAX_BLOCKS
+        if len(username) > max_len:
+            raise InvalidLengthError(f'username length must be not more than {max_len} characters')
+        if len(password) > max_len:
+            raise InvalidLengthError(f'password length must be not more than {max_len} characters')
         self._name = name
         self._ip_address = ip_address
         self._port = port
@@ -27,7 +31,7 @@ class LocalDevice:
             name_b64, _, ip_address_b64, port, _, username_enc_b64, password_enc_b64 = ampersand_string.split('&')
         except ValueError:
             raise MalformedDeviceDataError(
-                f'not enough fields in ampersand string (expected 7, got {ampersand_string.count('&')})'
+                f'not enough fields in ampersand string (expected 7, got {ampersand_string.count("&")})'
             )
         username = HikAES().decrypt_b64_to_str(username_enc_b64).rstrip('\x00')
         password = HikAES().decrypt_b64_to_str(password_enc_b64).rstrip('\x00')
@@ -39,9 +43,15 @@ class LocalDevice:
             password=password
         )
 
+    @staticmethod
+    def _pad_to_block(value: str, block_size: int = 16) -> str:
+        """Pad string to the next multiple of block_size using null bytes."""
+        padded_len = ((len(value) + block_size - 1) // block_size) * block_size
+        return value.ljust(padded_len, '\x00')
+
     def encode(self) -> str:
-        username_padded = self._username.ljust(16, '\x00')
-        password_padded = self._password.ljust(16, '\x00')
+        username_padded = self._pad_to_block(self._username)
+        password_padded = self._pad_to_block(self._password)
         return '&'.join([
             base64.b64encode(self._name.encode('utf-8')).decode(),
             '0',  # Always 0 in my cases (maybe device type)

--- a/qr_code_data.py
+++ b/qr_code_data.py
@@ -16,7 +16,7 @@ class QrCodeData:
             self,
             e2e_password: str,
             local_devices: [LocalDevice],
-            header: str = 'QRC03010003',
+            header: str = 'QRC03010002',
             timestamp_created: int = int(datetime.datetime.now().timestamp())
     ):
         if len(e2e_password) > 16:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ cffi==1.17.1
 click==8.1.8
 pyaes==1.6.1
 pycparser==2.22
-Pillow
-zxing-cpp

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ cffi==1.17.1
 click==8.1.8
 pyaes==1.6.1
 pycparser==2.22
+Pillow
+zxing-cpp


### PR DESCRIPTION
add: clipboard QR decode support and multi-block credential handling

- Add -c/--clipboard flag to decode command; reads QR image from macOS
  clipboard via PIL.ImageGrab + zxing-cpp (no brew dependency required)
- Extend HikAES to process multi-block ciphertext in decrypt/encrypt
- Raise username/password length limit from 16 to 32 chars (2 blocks)
- Fix default QR header constant in QrCodeData (QRC03010002)
- Add _pad_to_block helper in LocalDevice for block-aligned padding


---

*This is an anonymous contribution made via [gitGost](https://gitgost.leapcell.app).*

*The original author's identity has been anonymized to protect their privacy.*